### PR TITLE
Pfhub

### DIFF
--- a/schemas/projects.json
+++ b/schemas/projects.json
@@ -162,6 +162,37 @@
                         }
                     },
                     "additionalProperties": false
+                },
+                "pfhub": {
+                    "type": "object",
+                    "description": "Project block for PFHub.",
+                    "properties": {
+                        "cpu_architecture": {
+                            "type": "string"
+                        },
+                        "acc_architecture": {
+                            "type": "string"
+                        },
+                        "parallel_model": {
+                            "type": "string"
+                        },
+                        "clock_rate": {
+                            "type": "number"
+                        },
+                        "cores": {
+                            "type": "integer"
+                        },
+                        "nodes": {
+                            "type": "integer"
+                        },
+                        "benchmark_id": {
+                            "type": "string"
+                        },
+                        "benchmark_version": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": false
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
# Problem
The [Phase Field Community Hub](https://pages.nist.gov/pfhub/) wish to deposit simulation data in MDF. They have some specific fields they would like to use to search for records.

# Approach
This PR adds a new project type to the `projects` schema. Records belonging to the pfhub project can be annotated with data the community wish to search over.
 